### PR TITLE
Created DELETE Method for Articles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -83,6 +83,18 @@ public class ArticlesController extends ApiController {
         return articles;
     }
 
+    @Operation(summary= "Delete an article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticles(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles articles = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        articlesRepository.delete(articles);
+        return genericMessage("Articles with id %s deleted".formatted(id));
+    }
+
 
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,0 +1,75 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "Articles")
+@RequestMapping("/api/Articles")
+@RestController
+@Slf4j
+public class ArticlesController extends ApiController {
+
+    @Autowired
+    ArticlesRepository articlesRepository;
+
+    @Operation(summary= "List all articles")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Articles> allArticles() {
+        Iterable<Articles> articles = articlesRepository.findAll();
+        return articles;
+    }
+
+    @Operation(summary= "Create a new article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Articles postArticles(
+        @Parameter(name="title") @RequestParam String title,
+        @Parameter(name="url") @RequestParam String url,
+        @Parameter(name="explanation") @RequestParam String explanation,
+        @Parameter(name="email") @RequestParam String email,
+        @Parameter(name="dateAdded") @RequestParam("dateAdded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateAdded)
+        throws JsonProcessingException {
+
+    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    // See: https://www.baeldung.com/spring-date-parameters
+
+    log.info("dateAdded={}", dateAdded);
+
+    Articles articles = new Articles();
+    articles.setTitle(title);
+    articles.setUrl(url);
+    articles.setExplanation(explanation);
+    articles.setEmail(email);
+    articles.setDateAdded(dateAdded);
+
+    Articles savedArticles = articlesRepository.save(articles);
+
+    return savedArticles;
+}
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -55,21 +55,34 @@ public class ArticlesController extends ApiController {
         @Parameter(name="dateAdded") @RequestParam("dateAdded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateAdded)
         throws JsonProcessingException {
 
-    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    // See: https://www.baeldung.com/spring-date-parameters
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
 
-    log.info("dateAdded={}", dateAdded);
+        log.info("dateAdded={}", dateAdded);
 
-    Articles articles = new Articles();
-    articles.setTitle(title);
-    articles.setUrl(url);
-    articles.setExplanation(explanation);
-    articles.setEmail(email);
-    articles.setDateAdded(dateAdded);
+        Articles articles = new Articles();
+        articles.setTitle(title);
+        articles.setUrl(url);
+        articles.setExplanation(explanation);
+        articles.setEmail(email);
+        articles.setDateAdded(dateAdded);
 
-    Articles savedArticles = articlesRepository.save(articles);
+        Articles savedArticles = articlesRepository.save(articles);
 
-    return savedArticles;
-}
+        return savedArticles;
+    }
+
+    @Operation(summary= "Get a single article")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Articles getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles articles = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        return articles;
+    }
+
+
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String title;
+    private String url;
+    private String explanation;
+    private String email;
+    private LocalDateTime dateAdded;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "GarvinY",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_9"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TITLE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_ADDED",
+                      "type": "TIMESTAMP"
+                    }
+                  }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -202,5 +202,58 @@ public class ArticlesControllerTests extends ControllerTestCase {
         }
 
 
+        // Tests for DELETE /api/Articles?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_article() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("Wow")
+                                .url("coolmathgames.com")
+                                .explanation("cool stuff here")
+                                .email("email1")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(articles1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/Articles?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(15L);
+                verify(articlesRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Articles with id 15 deleted", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_article_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/Articles?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Articles with id 15 not found", json.get("message"));
+        }
+
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,146 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        ArticlesRepository articlesRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/Articles/all
+        
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/Articles/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/Articles/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_articles() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("How to Cure Cancer")
+                                .url("medicalwebsite.com/curingcancer")
+                                .explanation("this is how you cure cancer")
+                                .email("garvinwyoung@ucsb.edu")
+                                .dateAdded(ldt1)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+                Articles articles2 = Articles.builder()
+                                .title("How to Cure SPACE Cancer")
+                                .url("medicalwebsite.com/curingSPACEcancer")
+                                .explanation("this is how you cure SPACE cancer")
+                                .email("garvinwyoung@ucsb.edu")
+                                .dateAdded(ldt2)
+                                .build();
+
+                ArrayList<Articles> expectedArticles = new ArrayList<>();
+                expectedArticles.addAll(Arrays.asList(articles1, articles2));
+
+                when(articlesRepository.findAll()).thenReturn(expectedArticles);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/Articles/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedArticles);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/Articles/post...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/Articles/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/Articles/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_article() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("How to Cure SUPER SPACE Cancer")
+                                .url("medicalwebsite.com/curingSUPERSPACEcancer")
+                                .explanation("this is how you cure SUPER SPACE cancer")
+                                .email("garvinwyoung@ucsb.edu")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.save(eq(articles1))).thenReturn(articles1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/Articles/post?title=How to Cure SUPER SPACE Cancer&url=medicalwebsite.com/curingSUPERSPACEcancer&explanation=this is how you cure SUPER SPACE cancer&email=garvinwyoung@ucsb.edu&dateAdded=2022-01-03T00:00:00")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).save(articles1);
+                String expectedJson = mapper.writeValueAsString(articles1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -65,20 +65,20 @@ public class ArticlesControllerTests extends ControllerTestCase {
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 Articles articles1 = Articles.builder()
-                                .title("How to Cure Cancer")
-                                .url("medicalwebsite.com/curingcancer")
-                                .explanation("this is how you cure cancer")
-                                .email("garvinwyoung@ucsb.edu")
+                                .title("Wow")
+                                .url("coolmathgames.com")
+                                .explanation("cool stuff here")
+                                .email("email1")
                                 .dateAdded(ldt1)
                                 .build();
 
                 LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
 
                 Articles articles2 = Articles.builder()
-                                .title("How to Cure SPACE Cancer")
-                                .url("medicalwebsite.com/curingSPACEcancer")
-                                .explanation("this is how you cure SPACE cancer")
-                                .email("garvinwyoung@ucsb.edu")
+                                .title("Wow2")
+                                .url("coolmathgames.com2")
+                                .explanation("cool stuff here2")
+                                .email("email2")
                                 .dateAdded(ldt2)
                                 .build();
 
@@ -116,16 +116,16 @@ public class ArticlesControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void an_admin_user_can_post_a_new_article() throws Exception {
+        public void an_admin_user_can_post_a_new_articles() throws Exception {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 Articles articles1 = Articles.builder()
-                                .title("How to Cure SUPER SPACE Cancer")
-                                .url("medicalwebsite.com/curingSUPERSPACEcancer")
-                                .explanation("this is how you cure SUPER SPACE cancer")
-                                .email("garvinwyoung@ucsb.edu")
+                                .title("Wow")
+                                .url("coolmathgames.com")
+                                .explanation("cool stuff here")
+                                .email("email1")
                                 .dateAdded(ldt1)
                                 .build();
 
@@ -133,7 +133,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/Articles/post?title=How to Cure SUPER SPACE Cancer&url=medicalwebsite.com/curingSUPERSPACEcancer&explanation=this is how you cure SUPER SPACE cancer&email=garvinwyoung@ucsb.edu&dateAdded=2022-01-03T00:00:00")
+                                post("/api/Articles/post?title=Wow&url=coolmathgames.com&explanation=cool stuff here&email=email1&dateAdded=2022-01-03T00:00:00")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -143,4 +143,64 @@ public class ArticlesControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+        // Tests for GET /api/Articles?id=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/Articles?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("Wow")
+                                .url("coolmathgames.com")
+                                .explanation("cool stuff here")
+                                .email("email1")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(articles1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/Articles?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(articles1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/Articles?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Articles with id 7 not found", json.get("message"));
+        }
+
+
+
 }


### PR DESCRIPTION
In this PR, we added the DELETE functionality to Articles to delete a request in the database by ID.

Closes #42 