### PR TITLE
Add PUT (edit) endpoint for a single record in UCSBOrganization table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -60,7 +60,33 @@ public class UCSBOrganizationController extends ApiController {
         return savedOrganization;
     }
 
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
 
+        return organization;
+    }
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        organization.setOrgTranslation(incoming.getOrgTranslation());
+        organization.setOrgTranslationShort(incoming.getOrgTranslationShort());  
+        organization.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
 
    
     

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -60,16 +60,7 @@ public class UCSBOrganizationController extends ApiController {
         return savedOrganization;
     }
 
-    @Operation(summary= "Get a single organization")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("")
-    public UCSBOrganization getById(
-            @Parameter(name="orgCode") @RequestParam String orgCode) {
-        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
-                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
 
-        return organization;
-    }
 
    
     

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -87,7 +87,17 @@ public class UCSBOrganizationController extends ApiController {
 
         return organization;
     }
+    @Operation(summary= "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
 
+        ucsbOrganizationRepository.delete(organization);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
    
     
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,76 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/UCSBOrganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @Operation(summary= "List all ucsb organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrganizations() {
+        Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+        return organizations;
+    }
+
+    @Operation(summary= "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganization(
+         @Parameter(name = "orgCode") @RequestParam String orgCode,
+            @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+            @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+            @Parameter(name = "inactive") @RequestParam boolean inactive)
+        {
+
+        UCSBOrganization organizations = new UCSBOrganization();
+        organizations.setOrgCode(orgCode);
+        organizations.setOrgTranslationShort(orgTranslationShort);
+        organizations.setOrgTranslation(orgTranslation);
+        organizations.setInactive(inactive);
+
+        UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organizations);
+
+        return savedOrganization;
+    }
+
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
+
+   
+    
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganizations")
+public class UCSBOrganization {
+  @Id
+  private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+ 
+}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,68 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBOrganization-1",
+          "author": "RayD",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATIONS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_ORG"
+                      },
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ORG_TRANSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }]
+                ,
+                "tableName": "ucsborganizations"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -133,5 +133,96 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
-}
+                @WithMockUser(roles = { "USER" })
+        // Tests for PUT /api/UCSBOrganization?...
 
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("www"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=www"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("www"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id www not found", json.get("message"));
+        }
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_organization() throws Exception {
+                // arrange
+
+                UCSBOrganization coder = UCSBOrganization.builder()
+                                .orgCode("c")
+                                .orgTranslation("cooooder")
+                                .orgTranslationShort("Code")
+                                .inactive(false)
+                                .build();
+
+                UCSBOrganization coderEdited = UCSBOrganization.builder()
+                                .orgCode("c")
+                                .orgTranslation("coder")
+                                .orgTranslationShort("co")
+                                .inactive(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(coderEdited);
+
+                when(ucsbOrganizationRepository.findById(eq("c"))).thenReturn(Optional.of(coder));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/UCSBOrganization?orgCode=c")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("c");
+                verify(ucsbOrganizationRepository, times(1)).save(coderEdited); // should be saved with updated info
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBOrganization editedOrganization = UCSBOrganization.builder()
+                                .orgCode("abc")
+                                .orgTranslation("coder")
+                                .orgTranslationShort("co")
+                                .inactive(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(editedOrganization);
+
+                when(ucsbOrganizationRepository.findById(eq("abc"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/UCSBOrganization?orgCode=abc")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("abc");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id abc not found", json.get("message"));
+
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,137 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/ucsbOrganization/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbOrganization() throws Exception {
+
+                // arrange
+
+                UCSBOrganization coder = UCSBOrganization.builder()
+                                .orgCode("c")
+                                .orgTranslation("Coder")
+                                .orgTranslationShort("Code")
+                                .inactive(false)
+                                .build();
+
+                UCSBOrganization data = UCSBOrganization.builder()
+                                .orgCode("DS")
+                                .orgTranslation("Data Science")
+                                .orgTranslationShort("Data")
+                                .inactive(false)
+                                .build();
+
+                ArrayList<UCSBOrganization> expectedOrganization = new ArrayList<>();
+                expectedOrganization.addAll(Arrays.asList(coder,data));
+
+                when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganization);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedOrganization);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/UCSBOrganization...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_organization() throws Exception {
+                // arrange
+
+                UCSBOrganization gaucho = UCSBOrganization.builder()
+                                .orgCode("GR")
+                                .orgTranslation("GauchoRadio")
+                                .orgTranslationShort("GauRadio")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.save(eq(gaucho))).thenReturn(gaucho);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/UCSBOrganization/post?orgCode=GR&orgTranslation=GauchoRadio&orgTranslationShort=GauRadio&inactive=true")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).save(gaucho);
+                String expectedJson = mapper.writeValueAsString(gaucho);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}
+


### PR DESCRIPTION
In this PR, we added the PUT functionality to MenuItemReview to delete a request in the database by ID.


Closes https://github.com/ucsb-cs156-s24/team02-s24-4pm-5/issues/17