### PR TITLE
Add GET (show) endpoint for a single record in UCSBOrganization table

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -296,6 +296,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("UCSBOrganization with id www not found", json.get("message"));
         }
+        
 
 
 }


### PR DESCRIPTION
In this PR, we added the GET function for UCSBDiningCommonsMenuItem which gets a single record in the table.

Closes https://github.com/ucsb-cs156-s24/team02-s24-4pm-5/issues/16